### PR TITLE
Add Sigrid CI integration

### DIFF
--- a/.github/workflows/sigridci.yml
+++ b/.github/workflows/sigridci.yml
@@ -1,0 +1,20 @@
+name: sigridci
+on: [push, pull_request]
+jobs:
+  sigridci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+      - run: "git clone https://github.com/Software-Improvement-Group/sigridci.git sigridci"
+      - name: "Run Sigrid CI" 
+        env:
+          SIGRID_CI_ACCOUNT: "${{ secrets.SIGRID_CI_ACCOUNT }}"
+          SIGRID_CI_TOKEN: "${{ secrets.SIGRID_CI_TOKEN }}"
+        run: "./sigridci/sigridci/sigridci.py --customer bluebridgetech --system covid-green-backend-api --source . --targetquality 3.5" 
+      - name: "Save Sigrid CI results"
+        uses: actions/upload-artifact@v2
+        with:
+          path: "sigrid-ci-output/**"
+          retention-days: 7
+          


### PR DESCRIPTION
Note: this also requires two GitHub secrets with your Sigrid CI credentials: SIGRID_CI_ACCOUNT and SIGRID_CI_TOKEN. You can find more information in https://github.com/Software-Improvement-Group/sigridci/blob/main/github-actions.md